### PR TITLE
Add missing README reference for metrics-couchbase.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
  * bin/check-couchbase-bucket-replica.rb
  * bin/check-couchbase-cluster.rb
  * bin/metrics-couchbase.py
+ * bin/metrics-couchbase.rb
 
 ## Usage
 


### PR DESCRIPTION
#### General

- [ ] ~Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)~

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

metrics-couchbase.rb binstub is missing from README.