### PR TITLE
check-couchbase-cluster.rb: make cluster size check optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-couchbase-cluster.rb: make cluster size check optional
 
 ## [1.0.0] - 2016-04-28
 ### Added
@@ -11,7 +13,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Removed
 - support for Ruby 1.9.3 and 2.0
- 
+
 ### Fixed
 - binstub for python script
 

--- a/bin/check-couchbase-cluster.rb
+++ b/bin/check-couchbase-cluster.rb
@@ -104,7 +104,7 @@ class CheckCouchbaseCluster < Sensu::Plugin::Check::CLI
 
     warning "Cluster rebalance status #{results[:rebalanceStatus]}" if results[:rebalanceStatus] != 'none'
 
-    critical "Cluster's size is #{results[:nodes].size}, #{config[:cluster_size]} expected" if results[:nodes].size != config[:cluster_size]
+    critical "Cluster's size is #{results[:nodes].size}, #{config[:cluster_size]} expected" if config[:cluster_size] && results[:nodes].size != config[:cluster_size]
 
     ok "Nodes: #{results[:nodes].size}"
   end


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Changes the `-c` option (expected cluster size) to be an optional parameter, as other alerts exist in the check.

